### PR TITLE
fix NoSuchMethodError on getArrow in older versions

### DIFF
--- a/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
+++ b/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
@@ -58,7 +58,7 @@ public class Events implements Listener {
       Projectile projectile = (Projectile) event.getClass().getDeclaredMethod("getArrow").invoke(event);
       cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), projectile, event.getRemaining(), VersionUtils.isPaper() && event.getFlyAtPlayer());
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-      cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), null, 0, false);
+      cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), null, event.getRemaining(), false);
     }
     Bukkit.getPluginManager().callEvent(cbEvent);
     if(cbEvent.isCancelled()) {

--- a/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
+++ b/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
@@ -53,14 +53,13 @@ public class Events implements Listener {
 
   @EventHandler
   public void onPlayerPickupArrow(PlayerPickupArrowEvent event) {
-    Projectile projectile;
+    CBPlayerPickupArrow cbEvent;
     try {
-      projectile = (Projectile) event.getClass().getDeclaredMethod("getArrow").invoke(event);
+      Projectile projectile = (Projectile) event.getClass().getDeclaredMethod("getArrow").invoke(event);
+      cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), projectile, event.getRemaining(), VersionUtils.isPaper() && event.getFlyAtPlayer());
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-      e.printStackTrace();
-      return;
+      cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), null, 0, false);
     }
-    CBPlayerPickupArrow cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), projectile, event.getRemaining(), VersionUtils.isPaper() && event.getFlyAtPlayer());
     Bukkit.getPluginManager().callEvent(cbEvent);
     if(cbEvent.isCancelled()) {
       event.setCancelled(true);

--- a/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
+++ b/Commons Box Minecraft/src/main/java/pl/plajerlair/commonsbox/minecraft/compat/events/Events.java
@@ -19,6 +19,9 @@ import pl.plajerlair.commonsbox.minecraft.compat.events.api.CBPlayerInteractEnti
 import pl.plajerlair.commonsbox.minecraft.compat.events.api.CBPlayerInteractEvent;
 import pl.plajerlair.commonsbox.minecraft.compat.events.api.CBPlayerPickupArrow;
 import pl.plajerlair.commonsbox.minecraft.compat.events.api.CBPlayerSwapHandItemsEvent;
+
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * @author Tigerpanzer_02
  * <p>
@@ -50,7 +53,14 @@ public class Events implements Listener {
 
   @EventHandler
   public void onPlayerPickupArrow(PlayerPickupArrowEvent event) {
-    CBPlayerPickupArrow cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), (Projectile) event.getArrow(), event.getRemaining(), VersionUtils.isPaper() ? event.getFlyAtPlayer() : false);
+    Projectile projectile;
+    try {
+      projectile = (Projectile) event.getClass().getDeclaredMethod("getArrow").invoke(event);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      e.printStackTrace();
+      return;
+    }
+    CBPlayerPickupArrow cbEvent = new CBPlayerPickupArrow(event.getPlayer(), event.getItem(), projectile, event.getRemaining(), VersionUtils.isPaper() && event.getFlyAtPlayer());
     Bukkit.getPluginManager().callEvent(cbEvent);
     if(cbEvent.isCancelled()) {
       event.setCancelled(true);


### PR DESCRIPTION
Simple type casting is not helping.
Bytecodes also store the return type of the method.