### PR TITLE
fix: subtract health_boost from max_health

### DIFF
--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
@@ -366,7 +368,16 @@ public final class VersionUtils {
 
     java.util.Optional<org.bukkit.attribute.AttributeInstance> at = MiscUtils.getEntityAttribute(entity, Attribute.GENERIC_MAX_HEALTH);
     if(at.isPresent()) {
-      return at.get().getValue();
+      int health_boost = 0;
+  
+      PotionEffect effect = entity.getPotionEffect(PotionEffectType.HEALTH_BOOST);
+      if (effect != null) {
+        // Health boost effect has a base of 2 extra hearts then adds for 2 hearts for every level beyond
+        // 2 hearts (per level) is 4 half hearts (MAX_HEALTH is stored as half hearts)
+        health_boost = (effect.getAmplifier() + 1) * 4;
+      }
+
+      return at.get().getValue() - health_boost;
     }
 
     return 20D;

--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
@@ -20,8 +20,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
@@ -368,7 +366,7 @@ public final class VersionUtils {
 
     java.util.Optional<org.bukkit.attribute.AttributeInstance> at = MiscUtils.getEntityAttribute(entity, Attribute.GENERIC_MAX_HEALTH);
     if(at.isPresent()) {
-      return at.get().getValue() - health_boost;
+      return at.get().getValue();
     }
 
     return 20D;

--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
@@ -368,15 +368,6 @@ public final class VersionUtils {
 
     java.util.Optional<org.bukkit.attribute.AttributeInstance> at = MiscUtils.getEntityAttribute(entity, Attribute.GENERIC_MAX_HEALTH);
     if(at.isPresent()) {
-      int health_boost = 0;
-  
-      PotionEffect effect = entity.getPotionEffect(PotionEffectType.HEALTH_BOOST);
-      if (effect != null) {
-        // Health boost effect has a base of 2 extra hearts then adds for 2 hearts for every level beyond
-        // 2 hearts (per level) is 4 half hearts (MAX_HEALTH is stored as half hearts)
-        health_boost = (effect.getAmplifier() + 1) * 4;
-      }
-
       return at.get().getValue() - health_boost;
     }
 

--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
@@ -55,16 +55,6 @@ public class InventorySerializer {
       invConfig.set("ExperienceLevel", player.getLevel());
       invConfig.set("Current health", player.getHealth());
 
-      int max_health = VersionUtils.getMaxHealth(player);
-
-      PotionEffect effect = entity.getPotionEffect(PotionEffectType.HEALTH_BOOST);
-      if (effect != null) {
-        // Health boost effect has a base of 2 extra hearts then adds for 2 hearts for every level beyond
-        // 2 hearts (per level) is 4 half hearts (MAX_HEALTH is stored as half hearts)
-        max_health -= (effect.getAmplifier() + 1) * 4;
-      }
-
-      invConfig.set("Max health", max_health);
       invConfig.set("Food", player.getFoodLevel());
       invConfig.set("Saturation", player.getSaturation());
       invConfig.set("Fire ticks", player.getFireTicks());
@@ -77,10 +67,18 @@ public class InventorySerializer {
       java.util.Collection<PotionEffect> activeEffects = player.getActivePotionEffects();
       List<String> activePotions = new ArrayList<>(activeEffects.size());
 
+      double maxHealth = VersionUtils.getMaxHealth(player);
+
       for(PotionEffect potion : activeEffects) {
         activePotions.add(potion.getType().getName() + "#" + potion.getDuration() + "#" + potion.getAmplifier());
+        if (potion.getType().equals(PotionEffectType.HEALTH_BOOST)) {
+          // Health boost effect gives +2 hearts per level, health is counted in half hearts so amplifier * 4
+          maxHealth -= (potion.getAmplifier() + 1) * 4;
+        }
       }
+
       invConfig.set("Active potion effects", activePotions);
+      invConfig.set("Max health", maxHealth);
 
       org.bukkit.entity.HumanEntity holder = inventory.getHolder();
       if(holder instanceof Player) {

--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
@@ -55,7 +55,7 @@ public class InventorySerializer {
       invConfig.set("ExperienceLevel", player.getLevel());
       invConfig.set("Current health", player.getHealth());
 
-      int max_health = VersionUtils.getMaxHealth(player)
+      int max_health = VersionUtils.getMaxHealth(player);
 
       PotionEffect effect = entity.getPotionEffect(PotionEffectType.HEALTH_BOOST);
       if (effect != null) {

--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/serialization/InventorySerializer.java
@@ -54,7 +54,17 @@ public class InventorySerializer {
       invConfig.set("ExperienceProgress", player.getExp());
       invConfig.set("ExperienceLevel", player.getLevel());
       invConfig.set("Current health", player.getHealth());
-      invConfig.set("Max health", VersionUtils.getMaxHealth(player));
+
+      int max_health = VersionUtils.getMaxHealth(player)
+
+      PotionEffect effect = entity.getPotionEffect(PotionEffectType.HEALTH_BOOST);
+      if (effect != null) {
+        // Health boost effect has a base of 2 extra hearts then adds for 2 hearts for every level beyond
+        // 2 hearts (per level) is 4 half hearts (MAX_HEALTH is stored as half hearts)
+        max_health -= (effect.getAmplifier() + 1) * 4;
+      }
+
+      invConfig.set("Max health", max_health);
       invConfig.set("Food", player.getFoodLevel());
       invConfig.set("Saturation", player.getSaturation());
       invConfig.set("Fire ticks", player.getFireTicks());


### PR DESCRIPTION
Tested working on both 1.8 and 1.18

Reproduction steps:
- /effect give blalp minecraft:health_boost 30 30
- Join a murder lobby (/mm arenas)
- observe health at normal levels
- /mm leave
- /effect clear blalp (not strictly required, but for demonstration purposes)
- observe max health has been increased, effectively making the health boost effect permanent