### PR TITLE
fix: check particle class exists

### DIFF
--- a/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
+++ b/Commons Box Minecraft/src/main/java/plugily/projects/commonsbox/minecraft/compat/VersionUtils.java
@@ -73,6 +73,7 @@ public final class VersionUtils {
       Particle.class.getMethod("builder");
       isParticleBuilderSupported = true;
     } catch (NoSuchMethodException e) {
+    } catch (NoClassDefFoundError e) {
     }
 
     try {


### PR DESCRIPTION
Fixes class loading issue on 1.8 where plugin fails to load
https://paste.plugily.xyz/?4ab55647b232663e#AXJZGcF4S6tVwYeosEgFZtW5TSuVLyhs26zQQJ6M6ehP